### PR TITLE
pulumi dynamic providers for cyclone

### DIFF
--- a/pulumi-provider/__init__.py
+++ b/pulumi-provider/__init__.py
@@ -1,0 +1,4 @@
+from .cluster import *
+from .definition import *
+from .queue import *
+from .region import *

--- a/pulumi-provider/cluster.py
+++ b/pulumi-provider/cluster.py
@@ -1,0 +1,188 @@
+import json
+import os
+import time
+from typing import List
+from pulumi import Input, Output
+from pulumi.dynamic import Resource, ResourceProvider, CreateResult, UpdateResult, DiffResult
+import requests
+
+cyclone_name = os.environ['CYCLONE_NAME']
+cyclone_account = os.environ['CYCLONE_ACCOUNT']
+cyclone_main_region = os.environ['CYCLONE_MAIN_REGION']
+api_key = os.environ['CYCLONE_API_KEY']
+api_url = os.environ['CYCLONE_API_URL']
+
+def get_status(name):
+    message = json.dumps(
+                        {
+                            "operation": "GET",
+                            "TableName": cyclone_name+"_clusters_table",
+                            "payload":{"Key": {"name": name}
+                            }
+                        }  
+    )
+
+    header = {"x-api-key" : api_key}
+    post = requests.post(api_url, data=message, headers=header)
+    try:
+        json_response = post.json()['Item']['Status']
+    #only catch the actual error... if item is not in json, etc.
+    except:
+        json_response = None
+    return json_response
+
+class CycloneClusterArgs(object):
+    name: Input[str]
+    instance_list: Input[List[str]]
+    type: Input[str]
+    allocation_strategy: Input[str]
+    bid_percentage: Input[int]
+    max_vCPUs: Input[int]
+    iam_policies: Input[List[str]]
+    main_region_image_name: Input[str]
+
+    def __init__(
+        self,
+        name: Input[str],
+        instance_list: Input[List[str]] = ["optimal"],
+        type: Input[str] = "SPOT",
+        allocation_strategy: Input[str] = "SPOT_CAPACITY_OPTIMIZED",
+        bid_percentage: Input[int] = 100,
+        max_vCPUs: Input[int] = 1000,
+        iam_policies: Input[List[str]] = [],
+        main_region_image_name: Input[str] = "",
+    ):
+        self.name = name
+        self.instance_list = instance_list
+        self.type = type
+        self.allocation_strategy = allocation_strategy
+        self.bid_percentage = bid_percentage
+        self.max_vCPUs = max_vCPUs
+        self.iam_policies = iam_policies
+        self.main_region_image_name = main_region_image_name
+
+def cluster_to_props(incoming_prop):
+    result = {}
+    for name, value in incoming_prop.items():
+        if not name.startswith("_"):
+            if isinstance(value, float):
+                value = int(value)
+            elif isinstance(value, bool):
+                value = (str(value)).capitalize()
+            elif isinstance(value, (dict, list)):
+                value = json.dumps(value)
+            elif value is None:
+                value = ""
+
+            result[name] = value
+
+    return result
+
+
+class CycloneClusterProvider(ResourceProvider):
+    def create(self, props):
+        cluster = cluster_to_props(props)
+        cluster["Status"] = "Creating"
+        cluster["Output_Log"] = ""
+
+        data = json.dumps({
+            "operation": "POST",
+            "TableName": cyclone_name+"_clusters_table",
+            "payload": {"Item": cluster}
+        })
+
+        header = {"x-api-key" : api_key}
+
+        response = requests.post(api_url, data=data, headers=header)
+        if response.status_code != 200:
+            raise Exception("Error sending create to API: cyclone cluster")
+        
+        active = False
+        while not active:
+            time.sleep(10)
+            status = get_status(props["name"])
+            if status != "Creating":
+                if status == "ACTIVE":
+                    active = True
+                else:
+                    raise Exception("Error creating in AWS, check output logs: cyclone cluster")
+        
+        return CreateResult(props["name"], outs=props)
+
+    def diff(self, name: str, old, props):
+        replaces = []
+        stables = []
+        if (old["__provider"] != props["__provider"]): stables.append("__provider")
+        
+        return DiffResult(changes=old != props, replaces=replaces ,stables=stables, delete_before_replace=False)
+
+    def update(self, name: str, old, props):
+        cluster = cluster_to_props(props)
+        cluster["name"] = name
+        cluster["Status"] = "Updating"
+        cluster["Output_Log"] = ""
+
+        data = json.dumps({
+            "operation": "POST",
+            "TableName": cyclone_name+"_clusters_table",
+            "payload": {"Item": cluster}
+        })
+        header = {"x-api-key" : api_key}
+
+        response = requests.post(api_url, data=data, headers=header)
+        if response.status_code != 200:
+            raise Exception("Error sending update to API: cyclone cluster")
+
+        active = False
+        while not active:
+            time.sleep(10)
+            status = get_status(name)
+            if status != "Updating":
+                if status == "ACTIVE":
+                    active = True
+                else:
+                    raise Exception("Error updating in AWS, check output logs: cyclone cluster")
+
+        return UpdateResult(outs={**props})
+
+
+    def delete(self, name: str, props):
+        cluster = cluster_to_props(props)
+        cluster["name"] = name
+        cluster["Status"] = "Deleting"
+        cluster["Output_Log"] = ""
+        
+        data = json.dumps({
+            "operation": "POST",
+            "TableName": cyclone_name+"_clusters_table",
+            "payload": {"Item": cluster}
+        })
+
+        header = {"x-api-key" : api_key}
+        response = requests.post(api_url, data=data, headers=header)
+        if response.status_code != 200:
+            raise Exception("Error sending delete to API: cyclone cluster")
+
+        active = False
+        while not active:
+            time.sleep(10)
+            status = get_status(props["name"])
+            if status != "Deleting":
+                if status == "FAILED":
+                    raise Exception("Error deleting in AWS, check output logs: cyclone cluster")
+                else:
+                    return None
+
+
+class CycloneCluster(Resource):
+    name: Output[str]
+    instance_list: Output[List[str]]
+    type: Output[str]
+    allocation_strategy: Output[str]
+    bid_percentage: Output[int]
+    max_vCPUs: Output[int]
+    iam_policies: Output[List[str]]
+    main_region_image_name: Output[str]
+
+    def __init__(self, name, args: CycloneClusterArgs, opts=None):
+        super().__init__(CycloneClusterProvider(), name, vars(args), opts)

--- a/pulumi-provider/cluster.py
+++ b/pulumi-provider/cluster.py
@@ -1,7 +1,7 @@
 import json
 import os
 import time
-from typing import List
+from typing import Sequence
 from pulumi import Input, Output
 from pulumi.dynamic import Resource, ResourceProvider, CreateResult, UpdateResult, DiffResult
 import requests
@@ -33,23 +33,23 @@ def get_status(name):
 
 class CycloneClusterArgs(object):
     name: Input[str]
-    instance_list: Input[List[str]]
+    instance_list: Input[Sequence[str]]
     type: Input[str]
     allocation_strategy: Input[str]
     bid_percentage: Input[int]
     max_vCPUs: Input[int]
-    iam_policies: Input[List[str]]
+    iam_policies: Input[Sequence[str]]
     main_region_image_name: Input[str]
 
     def __init__(
         self,
         name: Input[str],
-        instance_list: Input[List[str]] = ["optimal"],
+        instance_list: Input[Sequence[str]] = ["optimal"],
         type: Input[str] = "SPOT",
         allocation_strategy: Input[str] = "SPOT_CAPACITY_OPTIMIZED",
         bid_percentage: Input[int] = 100,
         max_vCPUs: Input[int] = 1000,
-        iam_policies: Input[List[str]] = [],
+        iam_policies: Input[Sequence[str]] = [],
         main_region_image_name: Input[str] = "",
     ):
         self.name = name
@@ -176,12 +176,12 @@ class CycloneClusterProvider(ResourceProvider):
 
 class CycloneCluster(Resource):
     name: Output[str]
-    instance_list: Output[List[str]]
+    instance_list: Output[Sequence[str]]
     type: Output[str]
     allocation_strategy: Output[str]
     bid_percentage: Output[int]
     max_vCPUs: Output[int]
-    iam_policies: Output[List[str]]
+    iam_policies: Output[Sequence[str]]
     main_region_image_name: Output[str]
 
     def __init__(self, name, args: CycloneClusterArgs, opts=None):

--- a/pulumi-provider/definition.py
+++ b/pulumi-provider/definition.py
@@ -1,0 +1,235 @@
+import json
+import time
+import os
+from typing import Dict, List
+from pulumi import Input, Output
+from pulumi.dynamic import Resource, ResourceProvider, CreateResult, UpdateResult, DiffResult
+import requests
+
+cyclone_name = os.environ['CYCLONE_NAME']
+cyclone_account = os.environ['CYCLONE_ACCOUNT']
+cyclone_main_region = os.environ['CYCLONE_MAIN_REGION']
+api_key = os.environ['CYCLONE_API_KEY']
+api_url = os.environ['CYCLONE_API_URL']
+
+def get_status(name):
+    message = json.dumps(
+                        {
+                            "operation": "GET",
+                            "TableName": cyclone_name+"_jobDefinitions_table",
+                            "payload":{"Key": {"name": name}
+                            }
+                        }  
+    )
+
+    header = {"x-api-key" : api_key}
+    post = requests.post(api_url, data=message, headers=header)
+    try:
+        json_response = post.json()['Item']['Status']
+    #only catch the actual error... if item is not in json, etc.
+    except:
+        json_response = None
+    return json_response
+
+class CycloneDefinitionArgs(object):
+    name: Input[str]
+    use_cyclone_image: Input[bool]
+    cyclone_image_name: Input[str]
+    image_uri: Input[str]
+    vcpus: Input[int]
+    memory_limit_mib: Input[int]
+    linux_parameters: Input[str]
+    ulimits: Input[List[str]]
+    mount_points: Input[List[str]]
+    host_volumes: Input[List[str]]
+    gpu_count: Input[int]
+    environment: Input[Dict[str,str]]
+    privileged: Input[bool]
+    user: Input[str]
+    jobs_to_workers_ratio: Input[int]
+    timeout_minutes: Input[int]
+    iam_policies: Input[List[str]]
+    log_driver: Input[str]
+    log_options: Input[Dict[str,str]]
+    enable_qlog: Input[bool]
+
+    def __init__(
+        self,
+        name: Input[str],
+        use_cyclone_image: Input[bool] = False,
+        cyclone_image_name: Input[str] = "",
+        image_uri: Input[str] = "",
+        vcpus: Input[int] = 1,
+        memory_limit_mib: Input[int] = 2048,
+        linux_parameters: Input[str] = "",
+        ulimits: Input[List[str]] = [],
+        mount_points: Input[List[str]] = [],
+        host_volumes: Input[List[str]] = [],
+        gpu_count: Input[int] = "",
+        environment: Input[Dict[str,str]] = {"LOG_LEVEL": "INFO", "JSON_LOGGING": "True"},
+        privileged: Input[bool] = False,
+        user: Input[str] = "",
+        jobs_to_workers_ratio: Input[int] = 1,
+        timeout_minutes: Input[int] = "",
+        iam_policies: Input[List[str]] = [],
+        log_driver: Input[str] = "JSON_FILE",
+        log_options: Input[Dict[str,str]] = {"max-size": "10m", "max-file": "3"},
+        enable_qlog: Input[bool] = False,
+    ):
+        self.name = name
+        self.use_cyclone_image = use_cyclone_image
+        self.cyclone_image_name = cyclone_image_name
+        self.image_uri = image_uri
+        self.vcpus = vcpus
+        self.memory_limit_mib = memory_limit_mib
+        self.linux_parameters = linux_parameters
+        self.ulimits = ulimits
+        self.mount_points = mount_points
+        self.host_volumes = host_volumes
+        self.gpu_count = gpu_count
+        self.environment = environment
+        self.privileged = privileged
+        self.user = user
+        self.jobs_to_workers_ratio = jobs_to_workers_ratio
+        self.timeout_minutes = timeout_minutes
+        self.iam_policies = iam_policies
+        self.log_driver = log_driver
+        self.log_options = log_options
+        self.enable_qlog = enable_qlog
+
+def definition_to_props(incoming_prop):
+    result = {}
+    for name, value in incoming_prop.items():
+        if not name.startswith("_"):
+            if isinstance(value, float):
+                value = int(value)
+            elif isinstance(value, bool):
+                value = (str(value)).capitalize()
+            elif isinstance(value, (dict, list)):
+                value = json.dumps(value)
+            elif value is None:
+                value = ""
+
+            result[name] = value
+
+    return result
+
+
+class CycloneDefinitionProvider(ResourceProvider):
+    def create(self, props):
+        definition = definition_to_props(props)
+        definition["Status"] = "Creating"
+        definition["Output_Log"] = ""
+
+        data = json.dumps({
+            "operation": "POST",
+            "TableName": cyclone_name+"_jobDefinitions_table",
+            "payload": {"Item": definition}
+        })
+
+        header = {"x-api-key" : api_key}
+
+        response = requests.post(api_url, data=data, headers=header)
+        if response.status_code != 200:
+            raise Exception("Error sending create to API: cyclone definition")
+        
+        active = False
+        while not active:
+            time.sleep(10)
+            status = get_status(props["name"])
+            if status != "Creating":
+                if status == "ACTIVE":
+                    active = True
+                else:
+                    raise Exception("Error creating in AWS, check output logs: cyclone definition")
+        
+        return CreateResult(props["name"], outs=props)
+
+    def diff(self, name: str, old, props):
+        replaces = []
+        stables = []
+        if (old["__provider"] != props["__provider"]): stables.append("__provider")
+        
+        return DiffResult(changes=old != props, replaces=replaces ,stables=stables, delete_before_replace=False)
+
+    def update(self, name: str, old, props):
+        definition = definition_to_props(props)
+        definition["name"] = name
+        definition["Status"] = "Updating"
+        definition["Output_Log"] = ""
+
+        data = json.dumps({
+            "operation": "POST",
+            "TableName": cyclone_name+"_jobDefinitions_table",
+            "payload": {"Item": definition}
+        })
+        header = {"x-api-key" : api_key}
+
+        response = requests.post(api_url, data=data, headers=header)
+        if response.status_code != 200:
+            raise Exception("Error sending update to API: cyclone definition")
+
+        active = False
+        while not active:
+            time.sleep(10)
+            status = get_status(name)
+            if status != "Updating":
+                if status == "ACTIVE":
+                    active = True
+                else:
+                    raise Exception("Error updating in AWS, check output logs: cyclone definition")
+
+        return UpdateResult(outs={**props})
+
+
+    def delete(self, name: str, props):
+        definition = definition_to_props(props)
+        definition["name"] = name
+        definition["Status"] = "Deleting"
+        definition["Output_Log"] = ""
+        data = json.dumps({
+            "operation": "POST",
+            "TableName": cyclone_name+"_jobDefinitions_table",
+            "payload": {"Item": definition}
+        })
+
+        header = {"x-api-key" : api_key}
+        response = requests.post(api_url, data=data, headers=header)
+        if response.status_code != 200:
+            raise Exception("Error sending delete to API: cyclone definition")
+
+        active = False
+        while not active:
+            time.sleep(10)
+            status = get_status(props["name"])
+            if status != "Deleting":
+                if status == "FAILED":
+                    raise Exception("Error deleting in AWS, check output logs: cyclone definition")
+                else:
+                    return None
+
+
+class CycloneDefinition(Resource):
+    name: Output[str]
+    use_cyclone_image: Output[bool]
+    cyclone_image_name: Output[str]
+    image_uri: Output[str]
+    vcpus: Output[int]
+    memory_limit_mib: Output[int]
+    linux_parameters: Output[str]
+    ulimits: Output[List[str]]
+    mount_points: Output[List[str]]
+    host_volumes: Output[List[str]]
+    gpu_count: Output[int]
+    environment: Output[Dict[str,str]]
+    privileged: Output[bool]
+    user: Output[str]
+    jobs_to_workers_ratio: Output[int]
+    timeout_minutes: Output[int]
+    iam_policies: Output[List[str]]
+    log_driver: Output[str]
+    log_options: Output[Dict[str,str]]
+    enable_qlog: Output[bool]
+
+    def __init__(self, name, args: CycloneDefinitionArgs, opts=None):
+        super().__init__(CycloneDefinitionProvider(), name, vars(args), opts)

--- a/pulumi-provider/definition.py
+++ b/pulumi-provider/definition.py
@@ -1,7 +1,7 @@
 import json
 import time
 import os
-from typing import Dict, List
+from typing import Mapping, Sequence
 from pulumi import Input, Output
 from pulumi.dynamic import Resource, ResourceProvider, CreateResult, UpdateResult, DiffResult
 import requests
@@ -39,18 +39,18 @@ class CycloneDefinitionArgs(object):
     vcpus: Input[int]
     memory_limit_mib: Input[int]
     linux_parameters: Input[str]
-    ulimits: Input[List[str]]
-    mount_points: Input[List[str]]
-    host_volumes: Input[List[str]]
+    ulimits: Input[Sequence[str]]
+    mount_points: Input[Sequence[str]]
+    host_volumes: Input[Sequence[str]]
     gpu_count: Input[int]
-    environment: Input[Dict[str,str]]
+    environment: Input[Mapping[str,str]]
     privileged: Input[bool]
     user: Input[str]
     jobs_to_workers_ratio: Input[int]
     timeout_minutes: Input[int]
-    iam_policies: Input[List[str]]
+    iam_policies: Input[Sequence[str]]
     log_driver: Input[str]
-    log_options: Input[Dict[str,str]]
+    log_options: Input[Mapping[str,str]]
     enable_qlog: Input[bool]
 
     def __init__(
@@ -62,18 +62,18 @@ class CycloneDefinitionArgs(object):
         vcpus: Input[int] = 1,
         memory_limit_mib: Input[int] = 2048,
         linux_parameters: Input[str] = "",
-        ulimits: Input[List[str]] = [],
-        mount_points: Input[List[str]] = [],
-        host_volumes: Input[List[str]] = [],
+        ulimits: Input[Sequence[str]] = [],
+        mount_points: Input[Sequence[str]] = [],
+        host_volumes: Input[Sequence[str]] = [],
         gpu_count: Input[int] = "",
-        environment: Input[Dict[str,str]] = {"LOG_LEVEL": "INFO", "JSON_LOGGING": "True"},
+        environment: Input[Mapping[str,str]] = {"LOG_LEVEL": "INFO", "JSON_LOGGING": "True"},
         privileged: Input[bool] = False,
         user: Input[str] = "",
         jobs_to_workers_ratio: Input[int] = 1,
         timeout_minutes: Input[int] = "",
-        iam_policies: Input[List[str]] = [],
+        iam_policies: Input[Sequence[str]] = [],
         log_driver: Input[str] = "JSON_FILE",
-        log_options: Input[Dict[str,str]] = {"max-size": "10m", "max-file": "3"},
+        log_options: Input[Mapping[str,str]] = {"max-size": "10m", "max-file": "3"},
         enable_qlog: Input[bool] = False,
     ):
         self.name = name
@@ -217,18 +217,18 @@ class CycloneDefinition(Resource):
     vcpus: Output[int]
     memory_limit_mib: Output[int]
     linux_parameters: Output[str]
-    ulimits: Output[List[str]]
-    mount_points: Output[List[str]]
-    host_volumes: Output[List[str]]
+    ulimits: Output[Sequence[str]]
+    mount_points: Output[Sequence[str]]
+    host_volumes: Output[Sequence[str]]
     gpu_count: Output[int]
-    environment: Output[Dict[str,str]]
+    environment: Output[Mapping[str,str]]
     privileged: Output[bool]
     user: Output[str]
     jobs_to_workers_ratio: Output[int]
     timeout_minutes: Output[int]
-    iam_policies: Output[List[str]]
+    iam_policies: Output[Sequence[str]]
     log_driver: Output[str]
-    log_options: Output[Dict[str,str]]
+    log_options: Output[Mapping[str,str]]
     enable_qlog: Output[bool]
 
     def __init__(self, name, args: CycloneDefinitionArgs, opts=None):

--- a/pulumi-provider/queue.py
+++ b/pulumi-provider/queue.py
@@ -1,7 +1,7 @@
 import json
 import time
 import os
-from typing import Any, Dict
+from typing import Any, Mapping
 from pulumi import Input, Output
 from pulumi.dynamic import Resource, ResourceProvider, CreateResult, UpdateResult, DiffResult
 import requests
@@ -35,14 +35,14 @@ class CycloneQueueArgs(object):
     name: Input[str]
     computeEnvironment: Input[str]
     optimise_lowest_spot_cost_region: Input[bool]
-    region_distribution_weights: Input[Dict[str,int]]
+    region_distribution_weights: Input[Mapping[str, Any]]
 
     def __init__(
         self,
         name: Input[str],
         computeEnvironment: Input[str],
         optimise_lowest_spot_cost_region: Input[bool] = True,
-        region_distribution_weights: Input[Dict[str, Any]] = {"us-east-1": "auto"},
+        region_distribution_weights: Input[Mapping[str, Any]] = {"us-east-1": "auto"},
     ):
         self.name = name
         self.computeEnvironment = computeEnvironment
@@ -168,7 +168,7 @@ class CycloneQueue(Resource):
     name: Output[str]
     computeEnvironment: Output[str]
     optimise_lowest_spot_cost_region: Output[bool]
-    region_distribution_weights: Output[Dict[str, Any]]
+    region_distribution_weights: Output[Mapping[str, Any]]
 
     def __init__(self, name, args: CycloneQueueArgs, opts=None):
         super().__init__(CycloneQueueProvider(), name, vars(args), opts)

--- a/pulumi-provider/queue.py
+++ b/pulumi-provider/queue.py
@@ -1,0 +1,174 @@
+import json
+import time
+import os
+from typing import Any, Dict
+from pulumi import Input, Output
+from pulumi.dynamic import Resource, ResourceProvider, CreateResult, UpdateResult, DiffResult
+import requests
+
+cyclone_name = os.environ['CYCLONE_NAME']
+cyclone_account = os.environ['CYCLONE_ACCOUNT']
+cyclone_main_region = os.environ['CYCLONE_MAIN_REGION']
+api_key = os.environ['CYCLONE_API_KEY']
+api_url = os.environ['CYCLONE_API_URL']
+
+def get_status(name):
+    message = json.dumps(
+                        {
+                            "operation": "GET",
+                            "TableName": cyclone_name+"_queues_table",
+                            "payload":{"Key": {"name": name}
+                            }
+                        }  
+    )
+
+    header = {"x-api-key" : api_key}
+    post = requests.post(api_url, data=message, headers=header)
+    try:
+        json_response = post.json()['Item']['Status']
+    #only catch the actual error... if item is not in json, etc.
+    except:
+        json_response = None
+    return json_response
+
+class CycloneQueueArgs(object):
+    name: Input[str]
+    computeEnvironment: Input[str]
+    optimise_lowest_spot_cost_region: Input[bool]
+    region_distribution_weights: Input[Dict[str,int]]
+
+    def __init__(
+        self,
+        name: Input[str],
+        computeEnvironment: Input[str],
+        optimise_lowest_spot_cost_region: Input[bool] = True,
+        region_distribution_weights: Input[Dict[str, Any]] = {"us-east-1": "auto"},
+    ):
+        self.name = name
+        self.computeEnvironment = computeEnvironment
+        self.optimise_lowest_spot_cost_region = optimise_lowest_spot_cost_region
+        self.region_distribution_weights = region_distribution_weights
+
+def queue_to_props(incoming_prop):
+    result = {}
+    for name, value in incoming_prop.items():
+        if not name.startswith("_"):
+            if isinstance(value, float):
+                value = int(value)
+            elif isinstance(value, bool):
+                value = (str(value)).capitalize()
+            elif isinstance(value, (dict, list)):
+                value = json.dumps(value)
+            elif value is None:
+                value = ""
+
+            result[name] = value
+
+    return result
+
+
+class CycloneQueueProvider(ResourceProvider):
+    def create(self, props):
+        queue = queue_to_props(props)
+        queue["Status"] = "Creating"
+        queue["Output_Log"] = ""
+
+        data = json.dumps({
+            "operation": "POST",
+            "TableName": cyclone_name+"_queues_table",
+            "payload": {"Item": queue}
+        })
+
+        header = {"x-api-key" : api_key}
+
+        response = requests.post(api_url, data=data, headers=header)
+        if response.status_code != 200:
+            raise Exception("Error sending create to API: cyclone queue")
+        
+        active = False
+        while not active:
+            time.sleep(10)
+            status = get_status(props["name"])
+            if status != "Creating":
+                if status == "ACTIVE":
+                    active = True
+                else:
+                    raise Exception("Error creating in AWS, check output logs: cyclone queue")
+        
+        return CreateResult(props["name"], outs=props)
+
+
+    def diff(self, name: str, old, props):
+        replaces = []
+        stables = []
+        if (old["__provider"] != props["__provider"]): stables.append("__provider")
+        
+        return DiffResult(changes=old != props, replaces=replaces ,stables=stables, delete_before_replace=False)
+
+
+    def update(self, name: str, old, props):
+        queue = queue_to_props(props)
+        queue["name"] = name
+        queue["Status"] = "Updating"
+        queue["Output_Log"] = ""
+
+        data = json.dumps({
+            "operation": "POST",
+            "TableName": cyclone_name+"_queues_table",
+            "payload": {"Item": queue}
+        })
+        header = {"x-api-key" : api_key}
+
+        response = requests.post(api_url, data=data, headers=header)
+        if response.status_code != 200:
+            raise Exception("Error sending update to API: cyclone queue")
+
+        active = False
+        while not active:
+            time.sleep(10)
+            status = get_status(name)
+            if status != "Updating":
+                if status == "ACTIVE":
+                    active = True
+                else:
+                    raise Exception("Error updating in AWS, check output logs: cyclone queue")
+
+        return UpdateResult(outs={**props})
+
+
+    def delete(self, name: str, props):
+        queue = queue_to_props(props)
+        queue["name"] = name
+        queue["Status"] = "Deleting"
+        queue["Output_Log"] = ""
+        
+        data = json.dumps({
+            "operation": "POST",
+            "TableName": cyclone_name+"_queues_table",
+            "payload": {"Item": queue}
+        })
+
+        header = {"x-api-key" : api_key}
+        response = requests.post(api_url, data=data, headers=header)
+        if response.status_code != 200:
+            raise Exception("Error sending delete to API: cyclone queue")
+
+        active = False
+        while not active:
+            time.sleep(10)
+            status = get_status(props["name"])
+            if status != "Deleting":
+                if status == "FAILED":
+                    raise Exception("Error deleting in AWS, check output logs: cyclone queue")
+                else:
+                    return None
+
+
+class CycloneQueue(Resource):
+    name: Output[str]
+    computeEnvironment: Output[str]
+    optimise_lowest_spot_cost_region: Output[bool]
+    region_distribution_weights: Output[Dict[str, Any]]
+
+    def __init__(self, name, args: CycloneQueueArgs, opts=None):
+        super().__init__(CycloneQueueProvider(), name, vars(args), opts)

--- a/pulumi-provider/region.py
+++ b/pulumi-provider/region.py
@@ -1,0 +1,183 @@
+import json
+import time
+import os
+from pulumi import Input, Output
+from pulumi.dynamic import Resource, ResourceProvider, CreateResult, UpdateResult, DiffResult
+import requests
+
+cyclone_name = os.environ['CYCLONE_NAME']
+cyclone_account = os.environ['CYCLONE_ACCOUNT']
+cyclone_main_region = os.environ['CYCLONE_MAIN_REGION']
+api_key = os.environ['CYCLONE_API_KEY']
+api_url = os.environ['CYCLONE_API_URL']
+
+def get_status(name):
+    message = json.dumps(
+                        {
+                            "operation": "GET",
+                            "TableName": cyclone_name+"_regions_table",
+                            "payload":{"Key": {"name": name}
+                            }
+                        }  
+    )
+
+    header = {"x-api-key" : api_key}
+    post = requests.post(api_url, data=message, headers=header)
+    try:
+        json_response = post.json()['Item']['Status']
+    #only catch the actual error... if item is not in json, etc.
+    except:
+        json_response = None
+    return json_response
+
+class CycloneRegionArgs(object):
+    name: Input[str]
+    main_region: Input[bool]
+    import_vpc: Input[bool]
+    cidr: Input[str]
+    vpc_id: Input[str]
+    peer_with_main_region: Input[bool]
+    deploy_vpc_endpoints: Input[str]
+
+    def __init__(
+        self,
+        name: Input[str],
+        main_region: Input[bool] = False,
+        import_vpc: Input[bool] = True,
+        cidr: Input[str] = "null",
+        vpc_id: Input[str] = "",
+        peer_with_main_region: Input[bool] = False,
+        deploy_vpc_endpoints: Input[str] = "OFF",
+    ):
+        self.name = name
+        self.main_region = main_region
+        self.import_vpc = import_vpc
+        self.cidr = cidr
+        self.vpc_id = vpc_id
+        self.peer_with_main_region = peer_with_main_region
+        self.deploy_vpc_endpoints = deploy_vpc_endpoints
+
+def region_to_props(incoming_prop):
+    result = {}
+    for name, value in incoming_prop.items():
+        if not name.startswith("_"):
+            if isinstance(value, float):
+                value = int(value)
+            elif isinstance(value, bool):
+                value = (str(value)).capitalize()
+            elif isinstance(value, (dict, list)):
+                value = json.dumps(value)
+            elif value is None:
+                value = ""
+
+            result[name] = value
+
+    return result
+
+
+class CycloneRegionProvider(ResourceProvider):
+    def create(self, props):
+        region = region_to_props(props)
+        region["Status"] = "Creating"
+        region["Output_Log"] = ""
+
+        data = json.dumps({
+            "operation": "POST",
+            "TableName": cyclone_name+"_regions_table",
+            "payload": {"Item": region}
+        })
+
+        header = {"x-api-key" : api_key}
+
+        response = requests.post(api_url, data=data, headers=header)
+        if response.status_code != 200:
+            raise Exception("Error sending create to API: cyclone region")
+        
+        active = False
+        while not active:
+            time.sleep(10)
+            status = get_status(props["name"])
+            if status != "Creating":
+                if status == "ACTIVE":
+                    active = True
+                else:
+                    raise Exception("Error creating in AWS, check output logs: cyclone region")
+        
+        return CreateResult(props["name"], outs=props)
+
+    def diff(self, name: str, old, props):
+        replaces = []
+        stables = []
+        if (old["__provider"] != props["__provider"]): stables.append("__provider")
+        
+        return DiffResult(changes=old != props, replaces=replaces ,stables=stables, delete_before_replace=False)
+
+    def update(self, name: str, old, props):
+        region = region_to_props(props)
+        region["name"] = name
+        region["Status"] = "Updating"
+        region["Output_Log"] = ""
+
+        data = json.dumps({
+            "operation": "POST",
+            "TableName": cyclone_name+"_regions_table",
+            "payload": {"Item": region}
+        })
+        header = {"x-api-key" : api_key}
+
+        response = requests.post(api_url, data=data, headers=header)
+        if response.status_code != 200:
+            raise Exception("Error sending update to API: cyclone region")
+
+        active = False
+        while not active:
+            time.sleep(10)
+            status = get_status(name)
+            if status != "Updating":
+                if status == "ACTIVE":
+                    active = True
+                else:
+                    raise Exception("Error updating in AWS, check output logs: cyclone region")
+
+        return UpdateResult(outs={**props})
+
+
+    def delete(self, name: str, props):
+        region = region_to_props(props)
+        region["name"] = name
+        region["Status"] = "Deleting"
+        region["Output_Log"] = ""
+        
+        data = json.dumps({
+            "operation": "POST",
+            "TableName": cyclone_name+"_regions_table",
+            "payload": {"Item": region}
+        })
+
+        header = {"x-api-key" : api_key}
+        response = requests.post(api_url, data=data, headers=header)
+        if response.status_code != 200:
+            raise Exception("Error sending delete to API: cyclone region")
+
+        active = False
+        while not active:
+            time.sleep(10)
+            status = get_status(props["name"])
+            if status != "Deleting":
+                if status == "FAILED":
+                    raise Exception("Error deleting in AWS, check output logs: cyclone region")
+                else:
+                    return None
+
+
+class CycloneRegion(Resource):
+    name: Output[str]
+    main_region: Output[bool]
+    import_vpc: Output[bool]
+    cidr: Output[str]
+    vpc_id: Output[str]
+    peer_with_main_region: Output[bool]
+    deploy_vpc_endpoints: Output[str]
+
+    def __init__(self, name, args: CycloneRegionArgs, opts=None):
+        super().__init__(CycloneRegionProvider(), name, vars(args), opts)


### PR DESCRIPTION
*Description of changes:*

This dynamic provider hits the config API and places the creation/updating/and deletion under Pulumi control.


example usage:
`__main__.py`
```
"""A Python Pulumi program"""

import rtx_pulumi_helpers.providers.cyclone as cyclone


us_east_1 = cyclone.region.CycloneRegion(
    "NAME-us-east-1",
    cyclone.region.CycloneRegionArgs(
        name="us-east-1",
        main_region=True,
        peer_with_main_region=False,
        import_vpc=True,
        vpc_id="vpc-xxxxxxx",
        deploy_vpc_endpoints="OFF",
    ),
)

us_east_2 = cyclone.region.CycloneRegion(
    "NAME-us-east-2",
    cyclone.region.CycloneRegionArgs(
        name="us-east-2",
        main_region=False,
        peer_with_main_region=False,
        import_vpc=True,
        vpc_id="vpc-xxxxxxx",
        deploy_vpc_endpoints="OFF",
    ),
)

c_cluster = cyclone.cluster.CycloneCluster(
    "NAME-cluster",
    cyclone.cluster.CycloneClusterArgs(
        name="NAME-cluster",
        main_region_image_name="amazon-linux-2-20220328194725",
        instance_list=["r6i.large", "r6i.xlarge", "r6i.2xlarge"],
    ),
)

c_definition = cyclone.definition.CycloneDefinition(
    "NAME-definition",
    cyclone.definition.CycloneDefinitionArgs(
        name="NAME-definition",
        image_uri="00000000000.dkr.ecr.us-east-1.amazonaws.com/images/NAME",
        vcpus=1,
        memory_limit_mib=8000,
        iam_policies=["NAME-cyclone-s3-fullaccess"],
    ),
)

c_queue = cyclone.queue.CycloneQueue(
    "NAME-queue",
    cyclone.queue.CycloneQueueArgs(
        name="NAME",
        computeEnvironment=c_cluster.name,
        optimise_lowest_spot_cost_region=True,
        region_distribution_weights={"us-east-1": "auto", "us-east-2": "auto"},
    ),
)

```