### PR TITLE
chore: support manual ecr image replication

### DIFF
--- a/hyper_batch/hyper_job_definitions.py
+++ b/hyper_batch/hyper_job_definitions.py
@@ -103,8 +103,8 @@ class JobDefinitions(core.Stack):
             if job_definition['use_cyclone_image'] == "True":
                 image_uri = '{}.dkr.ecr.{}.amazonaws.com/{}:{}'.format(self.account, self.region, stack_name, job_definition['cyclone_image_name'])
             
-            elif "$REGION" in str(job_definition['image_uri']):
-                image_uri = str(job_definition['image_uri']).replace("$REGION", self.region)
+            elif "_REGION_" in str(job_definition['image_uri']):
+                image_uri = str(job_definition['image_uri']).replace("_REGION_", self.region)
             
             else:
                 image_uri = job_definition['image_uri']

--- a/hyper_batch/hyper_job_definitions.py
+++ b/hyper_batch/hyper_job_definitions.py
@@ -102,11 +102,12 @@ class JobDefinitions(core.Stack):
 
             if job_definition['use_cyclone_image'] == "True":
                 image_uri = '{}.dkr.ecr.{}.amazonaws.com/{}:{}'.format(self.account, self.region, stack_name, job_definition['cyclone_image_name'])
+            
+            elif "$REGION" in str(job_definition['image_uri']):
+                image_uri = str(job_definition['image_uri']).replace("$REGION", self.region)
+            
             else:
-                if "$REGION" in str(job_definition['image_uri']):
-                    image_uri = str(job_definition['image_uri']).replace("$REGION", self.region)
-                else:
-                    image_uri = job_definition['image_uri']
+                image_uri = job_definition['image_uri']
 
             container = ecs.ContainerImage.from_registry(image_uri)
 

--- a/hyper_batch/hyper_job_definitions.py
+++ b/hyper_batch/hyper_job_definitions.py
@@ -103,7 +103,10 @@ class JobDefinitions(core.Stack):
             if job_definition['use_cyclone_image'] == "True":
                 image_uri = '{}.dkr.ecr.{}.amazonaws.com/{}:{}'.format(self.account, self.region, stack_name, job_definition['cyclone_image_name'])
             else:
-                image_uri = job_definition['image_uri']
+                if "$REGION" in str(job_definition['image_uri']):
+                    image_uri = str(job_definition['image_uri']).replace("$REGION", self.region)
+                else:
+                    image_uri = job_definition['image_uri']
 
             container = ecs.ContainerImage.from_registry(image_uri)
 


### PR DESCRIPTION
If manual ECR image contains `_REGION_` in the region field, grab the region from the incoming parameters.

Allows customers to manually replicate custom ECR images and have each region's job definition use the replicated region.

ECR image must be replicated to all regions used in cyclone.
