### PR TITLE
fix: use LastEvaluatedKey to grab all rows in the scan

### DIFF
--- a/orchestrator.py
+++ b/orchestrator.py
@@ -244,11 +244,15 @@ with open("./hyper_batch/configuration/images.json", 'w') as outfile:
         json.dump(images, outfile)
 
 def scan_regions():
-    dynamo_regions = dynamo.scan(
+    ddb_response = dynamo.scan(
         TableName=stack_name + '_regions_table',
     )
 
-    dynamo_regions = dynamo_regions['Items']
+    dynamo_regions = ddb_response['Items']
+
+    while "LastEvaluatedKey" in ddb_response:
+        ddb_response = dynamo.scan(TableName=stack_name + '_regions_table', ExclusiveStartKey=ddb_response["LastEvaluatedKey"])
+        dynamo_regions.extend(ddb_response["Items"])
     logger.info('## CHECK REGIONS : ' + jsonpickle.encode(dynamo_regions))
 
 
@@ -284,11 +288,15 @@ def scan_regions():
     return dynamo_regions, regions
 
 def scan_clusters():
-    dynamo_clusters = dynamo.scan(
+    ddb_response = dynamo.scan(
         TableName=stack_name + '_clusters_table',
     )
 
-    dynamo_clusters = dynamo_clusters['Items']
+    dynamo_clusters = ddb_response['Items']
+    while "LastEvaluatedKey" in ddb_response:
+        ddb_response = dynamo.scan(TableName=stack_name + '_clusters_table', ExclusiveStartKey=ddb_response["LastEvaluatedKey"])
+        dynamo_clusters.extend(ddb_response["Items"])
+
 
     logger.info('## CHECK CLUSTERS : ' + jsonpickle.encode(dynamo_clusters))
 
@@ -384,11 +392,15 @@ def scan_definitions():
     return dynamo_jobDefinitions, jobDefinitions
 
 def scan_queues():
-    dynamo_queues = dynamo.scan(
+    ddb_response = dynamo.scan(
         TableName=stack_name + '_queues_table',
     )
 
-    dynamo_queues = dynamo_queues['Items']
+    dynamo_queues = ddb_response['Items']
+
+    while "LastEvaluatedKey" in ddb_response:
+        ddb_response = dynamo.scan(TableName=stack_name + '_queues_table', ExclusiveStartKey=ddb_response["LastEvaluatedKey"])
+        dynamo_queues.extend(ddb_response["Items"])
 
     logger.info('## CHECK QUEUES : ' + jsonpickle.encode(dynamo_queues))
 
@@ -427,11 +439,16 @@ def scan_images():
 
     result, status = do_work(['aws s3 sync s3://{}-images-{}/images ./hyper_batch/configuration/images'.format(stack_name, region)])
 
-    dynamo_images = dynamo.scan(
+    ddb_response = dynamo.scan(
         TableName=stack_name + '_images_table',
     )
 
-    dynamo_images = dynamo_images['Items']
+    dynamo_images = ddb_response['Items']
+
+    while "LastEvaluatedKey" in ddb_response:
+        ddb_response = dynamo.scan(TableName=stack_name + '_images_table', ExclusiveStartKey=ddb_response["LastEvaluatedKey"])
+        dynamo_images.extend(ddb_response["Items"])
+
 
     logger.info('## CHECK IMAGES : ' + jsonpickle.encode(dynamo_images))
     

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -324,11 +324,14 @@ def scan_clusters():
     return dynamo_clusters, clusters
 
 def scan_definitions():
-    dynamo_jobDefinitions = dynamo.scan(
+    ddb_response = dynamo.scan(
         TableName=stack_name + '_jobDefinitions_table',
     )
 
-    dynamo_jobDefinitions = dynamo_jobDefinitions['Items']
+    dynamo_jobDefinitions = ddb_response['Items']
+    while "LastEvaluatedKey" in ddb_response:
+        ddb_response = dynamo.scan(ExclusiveStartKey=ddb_response["LastEvaluatedKey"])
+        dynamo_jobDefinitions.extend(ddb_response["Items"])
 
     logger.info('## CHECK JOB DEFINITIONS : ' + jsonpickle.encode(dynamo_jobDefinitions))
     

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -330,7 +330,7 @@ def scan_definitions():
 
     dynamo_jobDefinitions = ddb_response['Items']
     while "LastEvaluatedKey" in ddb_response:
-        ddb_response = dynamo.scan(ExclusiveStartKey=ddb_response["LastEvaluatedKey"])
+        ddb_response = dynamo.scan(TableName=stack_name + '_jobDefinitions_table', ExclusiveStartKey=ddb_response["LastEvaluatedKey"])
         dynamo_jobDefinitions.extend(ddb_response["Items"])
 
     logger.info('## CHECK JOB DEFINITIONS : ' + jsonpickle.encode(dynamo_jobDefinitions))


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/aws-cyclone-solution/issues/22

*Description of changes:*
Loop through and use the LastEvaluatedKey to continue to grab items if we reach the limit.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
