### PR TITLE
fix: use job_definition from within the loop

### DIFF
--- a/hyper_batch/hyper_job_definitions.py
+++ b/hyper_batch/hyper_job_definitions.py
@@ -146,7 +146,7 @@ class JobDefinitions(core.Stack):
                 print(f'ERROR: log configs could not be interpreted' )
 
             try:
-                if 'linux_parameters' in job_definition:
+                if job_definition.get("linux_parameters"):
                     print(job_definition['linux_parameters'])
                     linux_parameters = ecs.LinuxParameters(self, str(job_definition['jobDefinitionName'] + '-LinuxParams'),
                         init_process_enabled=bool_convert(job_definition['linux_parameters']['init_process_enabled']),

--- a/hyper_batch/hyper_job_definitions.py
+++ b/hyper_batch/hyper_job_definitions.py
@@ -146,7 +146,7 @@ class JobDefinitions(core.Stack):
                 print(f'ERROR: log configs could not be interpreted' )
 
             try:
-                if 'linux_parameters' in job_definitions:
+                if 'linux_parameters' in job_definition:
                     print(job_definition['linux_parameters'])
                     linux_parameters = ecs.LinuxParameters(self, str(job_definition['jobDefinitionName'] + '-LinuxParams'),
                         init_process_enabled=bool_convert(job_definition['linux_parameters']['init_process_enabled']),


### PR DESCRIPTION
*Issue #, if available:*
Closes https://github.com/awslabs/aws-cyclone-solution/issues/25

*Description of changes:*
Currently, it is looking at `job_definitions` which is the job definitions array not the individual item.

check if `linux_parameters` exist on the current job_definition in the loop.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
