### PR TITLE
fix: import used ClientError on api handler

### DIFF
--- a/1-api-handler-lambda/api-handler-lambda.py
+++ b/1-api-handler-lambda/api-handler-lambda.py
@@ -22,6 +22,7 @@ import jsonpickle
 import uuid
 from datetime import datetime
 import decimal
+from botocore.exceptions import ClientError
 
 LOG_LEVEL = os.getenv("LOG_LEVEL", logging.ERROR)
 logger = logging.getLogger()


### PR DESCRIPTION
*Description of changes:*
ClientError is used down by line 194 however, it is no imported so the code crashes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
