### PR TITLE
feat: allow setting number of compute envs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,9 +10,9 @@
 /.vscode
 /ec2-controler/
 /scripts/
-/host_credentials/
 /hyper_batch/__pycache__/
 /host_credentials/*
+!/host_credentials/.gitkeep
 *.egg-info/
 *.egg
 *.pyc

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@
 /scripts/
 /host_credentials/
 /hyper_batch/__pycache__/
+/host_credentials/*
+*.egg-info/
+*.egg
+*.pyc

--- a/cyclone-cli/commands/clusters.py
+++ b/cyclone-cli/commands/clusters.py
@@ -95,12 +95,13 @@ def list_clusters(obj, name):
 @click.option('--name', required=True, prompt='Cluster name', help='Give cluster a name')
 @click.option('--instance-list', required=True, default=["optimal"], prompt='Instance types as list of strings e.g ["m5.large","c5.large"], default ["optimal"]', help='Instance types to use as a string list e.g ["m5.large","c5.large"], default is ["optimal"]')
 @click.option('--max-vCPUs', required=True, default='1000', show_default=True, prompt='Max vCPUs per region', help='Specify the maximum vCPUs per region, total max vCPUs will be regions enabled * max-vCPUs per region')
+@click.option('--compute-envs', required=False, default=3, show_default=True, prompt='Max Compute environments per cluster (max 3)', help='Amount of compute environments per cluster.. will divide max-vCPUs by compute-envs')
 @click.option('--type', required=True, default='SPOT', show_default=True, prompt='Choose [SPOT/ONDEMAND]', type=click.Choice(['SPOT','ONDEMAND'], case_sensitive=False),  help='Choose EC2 pricing plan [SPOT/ONDEMAND]')
 @click.option('--bid-percentage', required=False, default=None, help='For SPOT only - Bid percentage of on-demand cost')
 @click.option('--allocation-strategy', required=False, default=None, type=click.Choice(['SPOT_CAPACITY_OPTIMIZED','BEST_FIT_PROGRESSIVE', 'BEST_FIT'], case_sensitive=False), help='Batch allocation strategy to use [BEST_FIT_PROGRESSIVE/BEST_FIT/SPOT_CAPACITY_OPTIMIZED')
 @click.option('--iam-policies', required=False, default=[], prompt='OPTIONAL Add IAM policies to instance role as list of strings e.g ["custom_policy"]', help='Add additional IAM policies to instance role in your cluster (policies needed by hyper batch are automatically added)')
 @click.option('--main-region-image-name', required=False, default='', prompt='OPTIONAL Specify custom AMI name that exists in your main region to use for cluster', help='OPTIONAL Specify custom AMI name for an image that exists in your main region that you want to use for cluster. Cyclone will copy the image to any hub regions where it does not exist and use local versions')
-def add_cluster(obj, name, instance_list, max_vcpus, type, bid_percentage, allocation_strategy, iam_policies, main_region_image_name):
+def add_cluster(obj, name, instance_list, max_vcpus, compute_envs, type, bid_percentage, allocation_strategy, iam_policies, main_region_image_name):
     """Add a cluster to your environment, clusters will span all enabled regions."""
     instance_list = str(instance_list).replace("'", '"')
     iam_policies = str(iam_policies).replace("'", '"')
@@ -130,6 +131,7 @@ def add_cluster(obj, name, instance_list, max_vcpus, type, bid_percentage, alloc
         "allocation_strategy": allocation_strategy,
         "bid_percentage": bid_percentage,
         "max_vCPUs": max_vcpus,
+        "compute_envs": compute_envs,
         "iam_policies": iam_policies,
         "main_region_image_name": main_region_image_name,
         "Status": "Creating",
@@ -152,12 +154,13 @@ def add_cluster(obj, name, instance_list, max_vcpus, type, bid_percentage, alloc
 @click.option('--name', required=True, help='Choose cluster to update')
 @click.option('--instance-list', required=False, default=None, help='List instance types to use e.g "m5.xlarge c5.xlarge", you can also choose optimal')
 @click.option('--max-vCPUs', required=False, default=None, help='Specify the maximum vCPUs per region, total max vCPUs will be regions enabled * max-vCPUs per region')
+@click.option('--compute-envs', required=False, default=None, help='Amount of compute environments per cluster (max 3).. will divide max-vCPUs by compute-envs')
 @click.option('--type', required=False, default=None, help='Pricing option of spot or on-demand [SPOT/ON-DEMAND] ')
 @click.option('--bid-percentage', required=False, default=None, help='If import-vpc is True then specify the vpc-id to import')
 @click.option('--allocation-strategy', required=False, default=None, help='If set to True a peering connection is automatically create between hub region vpc and main region vpc for network communication')
 @click.option('--iam-policies', required=False, default=None, help='Add additional iam policies to instance role in your cluster e.g ["custom_policy"] (policies needed by hyper batch are automatically added)')
 @click.option('--main-region-image-name', required=False, default=None, help='OPTIONAL Specify Image name for an image that exists in your main region that you want to use for cluster. Cyclone will copy the image to any hub regions where it does not exist and use local versions')
-def update_cluster(obj, name, instance_list, max_vcpus, bid_percentage, type, allocation_strategy, iam_policies, main_region_image_name):
+def update_cluster(obj, name, instance_list, max_vcpus, compute_envs, bid_percentage, type, allocation_strategy, iam_policies, main_region_image_name):
     """Update specific configurations for an existing cluster"""
 
     params_old = get(obj.url, obj.key, obj.name +'_clusters_table', name)
@@ -168,6 +171,8 @@ def update_cluster(obj, name, instance_list, max_vcpus, bid_percentage, type, al
         params_old['type'] = type
     if not max_vcpus == None:
         params_old['max_vCPUs'] = max_vcpus
+    if not compute_envs == None:
+        params_old['compute_envs'] = compute_envs,
     if not allocation_strategy == None:
         params_old['allocation_strategy'] = allocation_strategy
     if not bid_percentage == None:
@@ -214,6 +219,3 @@ def delete_cluster(obj, name):
     click.echo('Status')
     click.echo(cluster['Status'])
     click.echo('')
-
-
-

--- a/cyclone-cli/commands/clusters.py
+++ b/cyclone-cli/commands/clusters.py
@@ -172,7 +172,7 @@ def update_cluster(obj, name, instance_list, max_vcpus, compute_envs, bid_percen
     if not max_vcpus == None:
         params_old['max_vCPUs'] = max_vcpus
     if not compute_envs == None:
-        params_old['compute_envs'] = compute_envs,
+        params_old['compute_envs'] = compute_envs
     if not allocation_strategy == None:
         params_old['allocation_strategy'] = allocation_strategy
     if not bid_percentage == None:

--- a/hyper_batch/configuration/example_config_files/clusters.json
+++ b/hyper_batch/configuration/example_config_files/clusters.json
@@ -1,23 +1,31 @@
-{ "clusters":[
+{
+    "clusters": [
         {
             "clusterName": "sample-cluster-1",
-            "instance_list": ["optimal"],
+            "instance_list": [
+                "optimal"
+            ],
             "type": "SPOT",
             "allocation_strategy": "SPOT_CAPACITY_OPTIMIZED",
             "bid_percentage": 100,
             "max_vCPUs": 1000,
-            "iam_policies":[],
+            "compute_envs": 3,
+            "iam_policies": [],
             "main_region_image_name": null
         },
         {
             "clusterName": "sample-cluster-2",
-            "instance_list": ["m4.2xlarge", "m4.4xlarge"],
+            "instance_list": [
+                "m4.2xlarge",
+                "m4.4xlarge"
+            ],
             "type": "SPOT",
             "allocation_strategy": "SPOT_CAPACITY_OPTIMIZED",
             "bid_percentage": 100,
             "max_vCPUs": 1000,
-            "iam_policies":[],
+            "compute_envs": 1,
+            "iam_policies": [],
             "main_region_image_name": null
         }
     ]
-  }
+}

--- a/hyper_batch/hyper_clusters.py
+++ b/hyper_batch/hyper_clusters.py
@@ -422,7 +422,8 @@ class Clusters(core.Stack):
 
             if not cluster['max_vCPUs'] == 0:
                 max_vCPUs = ceil(cluster['max_vCPUs'] / cluster['compute_envs'])
-
+            else:
+                max_vCPUs = 0
 
             for i in range(1, int(cluster['compute_envs']), 1):
                 CE_name = batch.ComputeEnvironment(self, id=stack_name + '-' + cluster['clusterName'] + '-' + str(i),

--- a/hyper_batch/hyper_clusters.py
+++ b/hyper_batch/hyper_clusters.py
@@ -425,7 +425,7 @@ class Clusters(core.Stack):
             else:
                 max_vCPUs = 0
 
-            for i in range(1, int(cluster['compute_envs']), 1):
+            for i in range(0, int(cluster['compute_envs']), 1):
                 CE_name = batch.ComputeEnvironment(self, id=stack_name + '-' + cluster['clusterName'] + '-' + str(i),
                     compute_resources={
                         "type": batch.ComputeResourceType(cluster['type']),
@@ -445,7 +445,7 @@ class Clusters(core.Stack):
                     # Defines a collection of compute resources to handle assigned batch jobs
                     compute_environment=CE_name,
                     # Order determines the allocation order for jobs (i.e. Lower means higher preferance for job assignment)
-                    order=i
+                    order=i + 1
                 )
                 envs.append(ENV_name)
 

--- a/hyper_batch/hyper_clusters.py
+++ b/hyper_batch/hyper_clusters.py
@@ -27,6 +27,7 @@ from aws_cdk import (
 import aws_cdk.aws_batch_alpha as batch
 from constructs import Construct
 from aws_cdk.custom_resources import Provider
+from math import ceil
 
 import os
 import subprocess
@@ -356,11 +357,7 @@ class Clusters(core.Stack):
                 instance_types.append(instace_type)
 
             envs = []
-            if cluster['max_vCPUs'] == 0:
-                max_vCPUs = 0
-            else:
-                max_vCPUs = round(0.5 + cluster['max_vCPUs'] / 3)
-            
+           
             image_object = None
             if not cluster['main_region_image_name'] == None or cluster['main_region_image_name'] == '':
                 ec2_local = boto3.client('ec2', region_name=self.region)
@@ -417,14 +414,17 @@ class Clusters(core.Stack):
                     print('AMI copied and available to cyclone')
 
 
-
             lt_raw = ec2.CfnLaunchTemplate(self, stack_name + '-' + cluster['clusterName'] + '-' + 'lt',
                 launch_template_name=stack_name + '-' + cluster['clusterName'] + '-' + 'lt',
                 launch_template_data=ec2.CfnLaunchTemplate.LaunchTemplateDataProperty(instance_type="t3.small")
                 )
             lt = batch.LaunchTemplateSpecification(launch_template_name=lt_raw.launch_template_name)
 
-            for i in range(1, 4, 1):
+            if not cluster['max_vCPUs'] == 0:
+                max_vCPUs = ceil(cluster['max_vCPUs'] / cluster['compute_envs'])
+
+
+            for i in range(1, int(cluster['compute_envs']), 1):
                 CE_name = batch.ComputeEnvironment(self, id=stack_name + '-' + cluster['clusterName'] + '-' + str(i),
                     compute_resources={
                         "type": batch.ComputeResourceType(cluster['type']),
@@ -434,7 +434,7 @@ class Clusters(core.Stack):
                         "image": image_object,
                         "bid_percentage": cluster['bid_percentage'], # Bids for resources at 75% of the on-demand price
                         "vpc": vpc,
-                        "maxv_cpus": int(cluster['max_vCPUs'] / 3),
+                        "maxv_cpus": max_vCPUs,
                         "instance_role": f'arn:aws:iam::{self.account}:instance-profile/{stack_name}-InstanceProfile'
                     },
                     service_role=batchServiceRole,

--- a/pulumi-provider/cluster.py
+++ b/pulumi-provider/cluster.py
@@ -38,6 +38,7 @@ class CycloneClusterArgs(object):
     allocation_strategy: Input[str]
     bid_percentage: Input[int]
     max_vCPUs: Input[int]
+    compute_envs: Input[int]
     iam_policies: Input[Sequence[str]]
     main_region_image_name: Input[str]
 
@@ -49,6 +50,7 @@ class CycloneClusterArgs(object):
         allocation_strategy: Input[str] = "SPOT_CAPACITY_OPTIMIZED",
         bid_percentage: Input[int] = 100,
         max_vCPUs: Input[int] = 1000,
+        compute_envs: Input[int] = 3,
         iam_policies: Input[Sequence[str]] = [],
         main_region_image_name: Input[str] = "",
     ):
@@ -58,6 +60,7 @@ class CycloneClusterArgs(object):
         self.allocation_strategy = allocation_strategy
         self.bid_percentage = bid_percentage
         self.max_vCPUs = max_vCPUs
+        self.compute_envs = compute_envs
         self.iam_policies = iam_policies
         self.main_region_image_name = main_region_image_name
 
@@ -181,6 +184,7 @@ class CycloneCluster(Resource):
     allocation_strategy: Output[str]
     bid_percentage: Output[int]
     max_vCPUs: Output[int]
+    compute_envs: Output[int]
     iam_policies: Output[Sequence[str]]
     main_region_image_name: Output[str]
 


### PR DESCRIPTION
*Description of changes:*

Allow setting the amount of compute environments. Currently, batch supports up to 3 per job queue.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
