### PR TITLE
fix: use .get to avoid exception if not exists

### DIFF
--- a/0-worker-agent/batch_processor.py
+++ b/0-worker-agent/batch_processor.py
@@ -203,7 +203,7 @@ def main():
             'cpu_arch': {
                 'S': info.get('arch', 'null')},
             'cpu_count': {
-                'S': str(info.get('count'), 'null') if 'count' in info else None},
+                'S': str(info.get('count'), 'null') if 'count' in info else 'null'},
             'cpu_brand': {
                 'S':info.get('brand_raw', 'null')},
             'cpu_Hz': {

--- a/0-worker-agent/batch_processor.py
+++ b/0-worker-agent/batch_processor.py
@@ -201,13 +201,13 @@ def main():
             'jobDefinition': {
                 'S':jobDefinition},
             'cpu_arch': {
-                'S': info.get('arch')},
+                'S': info.get('arch', 'null')},
             'cpu_count': {
-                'S': str(info.get('count')) if 'count' in info else None},
+                'S': str(info.get('count'), 'null') if 'count' in info else None},
             'cpu_brand': {
-                'S':info.get('brand_raw')},
+                'S':info.get('brand_raw', 'null')},
             'cpu_Hz': {
-                'S':info.get('hz_advertised_friendly')},
+                'S':info.get('hz_advertised_friendly', 'null')},
             'mem_total_gb': {
                 'S':str(mem_info['total']/1000000000) or None},
             'mem_available_gb': {

--- a/0-worker-agent/batch_processor.py
+++ b/0-worker-agent/batch_processor.py
@@ -201,13 +201,13 @@ def main():
             'jobDefinition': {
                 'S':jobDefinition},
             'cpu_arch': {
-                'S': info['arch'] or None},
+                'S': info.get('arch')},
             'cpu_count': {
-                'S': str(info['count']) or None},
+                'S': str(info.get('count')},
             'cpu_brand': {
-                'S':info['brand_raw'] or None},
+                'S':info.get('brand_raw')},
             'cpu_Hz': {
-                'S':info['hz_advertised_friendly'] or None},
+                'S':info.get('hz_advertised_friendly')},
             'mem_total_gb': {
                 'S':str(mem_info['total']/1000000000) or None},
             'mem_available_gb': {

--- a/0-worker-agent/batch_processor.py
+++ b/0-worker-agent/batch_processor.py
@@ -203,7 +203,7 @@ def main():
             'cpu_arch': {
                 'S': info.get('arch')},
             'cpu_count': {
-                'S': str(info.get('count')},
+                'S': str(info.get('count')) if 'count' in info else None},
             'cpu_brand': {
                 'S':info.get('brand_raw')},
             'cpu_Hz': {


### PR DESCRIPTION
*Description of changes:*

use .get method on dictionary items to avoid an exception if the item doesn't exist. Defaults to None if item doesn't exist.

Fixes issues with Graviton ARM processors that don't seem to have a `brand_raw` value.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
