### PR TITLE
feat: add ability to tag compute env ec2

### DIFF
--- a/cyclone-cli/commands/clusters.py
+++ b/cyclone-cli/commands/clusters.py
@@ -99,8 +99,9 @@ def list_clusters(obj, name):
 @click.option('--bid-percentage', required=False, default=None, help='For SPOT only - Bid percentage of on-demand cost')
 @click.option('--allocation-strategy', required=False, default=None, type=click.Choice(['SPOT_CAPACITY_OPTIMIZED','BEST_FIT_PROGRESSIVE', 'BEST_FIT'], case_sensitive=False), help='Batch allocation strategy to use [BEST_FIT_PROGRESSIVE/BEST_FIT/SPOT_CAPACITY_OPTIMIZED')
 @click.option('--iam-policies', required=False, default=[], prompt='OPTIONAL Add IAM policies to instance role as list of strings e.g ["custom_policy"]', help='Add additional IAM policies to instance role in your cluster (policies needed by hyper batch are automatically added)')
+@click.option('--compute-resources-tags', type=(str, str), multiple=True, default={}, required=False, help='Assign tags for cluster, Repeat for multiple tags e.g "--compute-resources-tags TAGKEY1 TAGVALUE1 --compute-resources-tags TAGKEY2 TAGVALUE2".')
 @click.option('--main-region-image-name', required=False, default='', prompt='OPTIONAL Specify custom AMI name that exists in your main region to use for cluster', help='OPTIONAL Specify custom AMI name for an image that exists in your main region that you want to use for cluster. Cyclone will copy the image to any hub regions where it does not exist and use local versions')
-def add_cluster(obj, name, instance_list, max_vcpus, type, bid_percentage, allocation_strategy, iam_policies, main_region_image_name):
+def add_cluster(obj, name, instance_list, max_vcpus, type, bid_percentage, allocation_strategy, iam_policies, compute_resources_tags, main_region_image_name):
     """Add a cluster to your environment, clusters will span all enabled regions."""
     instance_list = str(instance_list).replace("'", '"')
     iam_policies = str(iam_policies).replace("'", '"')
@@ -122,6 +123,11 @@ def add_cluster(obj, name, instance_list, max_vcpus, type, bid_percentage, alloc
             bid_percentage = click.prompt('Choose spot bid percentage', default='100', show_default=True)
         if allocation_strategy == None:
             allocation_strategy = click.prompt('Choose spot allocation strategy', show_default=True, default='SPOT_CAPACITY_OPTIMIZED', type=click.Choice(['SPOT_CAPACITY_OPTIMIZED','BEST_FIT_PROGRESSIVE', 'BEST_FIT'], case_sensitive=False))
+    
+    compute_resources_tags_dict = {}
+    for item in compute_resources_tags:
+        k, v = item
+        compute_resources_tags_dict[k] = v
 
     cluster = {
         "name": name,
@@ -131,6 +137,7 @@ def add_cluster(obj, name, instance_list, max_vcpus, type, bid_percentage, alloc
         "bid_percentage": bid_percentage,
         "max_vCPUs": max_vcpus,
         "iam_policies": iam_policies,
+        "compute_resources_tags": json.dumps(compute_resources_tags_dict),
         "main_region_image_name": main_region_image_name,
         "Status": "Creating",
         "Output_Log": ''
@@ -156,8 +163,9 @@ def add_cluster(obj, name, instance_list, max_vcpus, type, bid_percentage, alloc
 @click.option('--bid-percentage', required=False, default=None, help='If import-vpc is True then specify the vpc-id to import')
 @click.option('--allocation-strategy', required=False, default=None, help='If set to True a peering connection is automatically create between hub region vpc and main region vpc for network communication')
 @click.option('--iam-policies', required=False, default=None, help='Add additional iam policies to instance role in your cluster e.g ["custom_policy"] (policies needed by hyper batch are automatically added)')
+@click.option('--compute-resources-tags', type=(str, str), multiple=True, default=None, required=False, help='Assign tags for cluster, Repeat for multiple tags e.g "--compute-resources-tags TAGKEY1 TAGVALUE1 --compute-resources-tags TAGKEY2 TAGVALUE2".')
 @click.option('--main-region-image-name', required=False, default=None, help='OPTIONAL Specify Image name for an image that exists in your main region that you want to use for cluster. Cyclone will copy the image to any hub regions where it does not exist and use local versions')
-def update_cluster(obj, name, instance_list, max_vcpus, bid_percentage, type, allocation_strategy, iam_policies, main_region_image_name):
+def update_cluster(obj, name, instance_list, max_vcpus, bid_percentage, type, allocation_strategy, iam_policies, compute_resources_tags, main_region_image_name):
     """Update specific configurations for an existing cluster"""
 
     params_old = get(obj.url, obj.key, obj.name +'_clusters_table', name)
@@ -174,6 +182,12 @@ def update_cluster(obj, name, instance_list, max_vcpus, bid_percentage, type, al
         params_old['bid_percentage'] = bid_percentage
     if not iam_policies == None:
         params_old['iam_policies'] = iam_policies
+    if not len(compute_resources_tags) == 0:
+        compute_resources_tags_dict = {}
+        for item in compute_resources_tags:
+            k, v = item
+            compute_resources_tags_dict[k] = v
+        params_old['compute_resources_tags'] = json.dumps(compute_resources_tags_dict)
     if not main_region_image_name == None:
         params_old['main_region_image_name'] = main_region_image_name
     params_old['Status'] ='Updating'

--- a/hyper_batch/configuration/example_config_files/clusters.json
+++ b/hyper_batch/configuration/example_config_files/clusters.json
@@ -7,6 +7,7 @@
             "bid_percentage": 100,
             "max_vCPUs": 1000,
             "iam_policies":[],
+            "compute_resources_tags": {},
             "main_region_image_name": null
         },
         {
@@ -17,6 +18,7 @@
             "bid_percentage": 100,
             "max_vCPUs": 1000,
             "iam_policies":[],
+            "compute_resources_tags": {"Environment": "Production", "CostCenter": "MachineLearning"},
             "main_region_image_name": null
         }
     ]

--- a/hyper_batch/hyper_clusters.py
+++ b/hyper_batch/hyper_clusters.py
@@ -424,11 +424,18 @@ class Clusters(core.Stack):
                 )
             lt = batch.LaunchTemplateSpecification(launch_template_name=lt_raw.launch_template_name)
 
+            if cluster.get('compute_resources_tags'):
+                print(f"{cluster['clusterName']} tags:{cluster['compute_resources_tags']}")
+                compute_tags = cluster['compute_resources_tags']
+            else:
+                compute_tags = {}
+
             for i in range(1, 4, 1):
                 CE_name = batch.ComputeEnvironment(self, id=stack_name + '-' + cluster['clusterName'] + '-' + str(i),
                     compute_resources={
                         "type": batch.ComputeResourceType(cluster['type']),
                         "allocation_strategy": batch.AllocationStrategy(cluster['allocation_strategy']),
+                        "compute_resources_tags": compute_tags,
                         "instance_types": instance_types,
                         "launch_template": lt,
                         "image": image_object,

--- a/pulumi-provider/cluster.py
+++ b/pulumi-provider/cluster.py
@@ -1,7 +1,7 @@
 import json
 import os
 import time
-from typing import Sequence
+from typing import Any, Mapping, Sequence
 from pulumi import Input, Output
 from pulumi.dynamic import Resource, ResourceProvider, CreateResult, UpdateResult, DiffResult
 import requests
@@ -39,6 +39,7 @@ class CycloneClusterArgs(object):
     bid_percentage: Input[int]
     max_vCPUs: Input[int]
     iam_policies: Input[Sequence[str]]
+    compute_resources_tags: Input[Mapping[str, Any]]
     main_region_image_name: Input[str]
 
     def __init__(
@@ -50,6 +51,7 @@ class CycloneClusterArgs(object):
         bid_percentage: Input[int] = 100,
         max_vCPUs: Input[int] = 1000,
         iam_policies: Input[Sequence[str]] = [],
+        compute_resources_tags: Input[Mapping[str, Any]] = {},
         main_region_image_name: Input[str] = "",
     ):
         self.name = name
@@ -59,6 +61,7 @@ class CycloneClusterArgs(object):
         self.bid_percentage = bid_percentage
         self.max_vCPUs = max_vCPUs
         self.iam_policies = iam_policies
+        self.compute_resources_tags = compute_resources_tags
         self.main_region_image_name = main_region_image_name
 
 def cluster_to_props(incoming_prop):
@@ -182,6 +185,7 @@ class CycloneCluster(Resource):
     bid_percentage: Output[int]
     max_vCPUs: Output[int]
     iam_policies: Output[Sequence[str]]
+    compute_resources_tags: Output[Mapping[str, Any]]
     main_region_image_name: Output[str]
 
     def __init__(self, name, args: CycloneClusterArgs, opts=None):


### PR DESCRIPTION
*Description of changes:*

Gives the ability to add tags to the cluster, which will push down to the EC2 Instances that batch spins up. It takes a dictionary of keys and values.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
